### PR TITLE
dist.ini: Fix Kwalitee issues

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -13,3 +13,9 @@ Time::Piece = 1.32
 Time::Local = 1.26
 Date::Parse = 1.17
 Time::ParseDate = 2015.0925
+
+[MetaYAML]
+
+[ReadmeAnyFromPod]
+[ReadmeAnyFromPod / ReadmePodInRoot]
+type = pod


### PR DESCRIPTION
This PR is a submission for my [CPAN Pull Request Challenge this month](http://cpan-prc.org/2018/august.html).  (link not ready yet, hopefully soon when Neil updates the site.)

This fixes the `has_meta_yml` and `has_readme` issues listed in https://cpants.cpanauthors.org/dist/Date-Easy:

- Add Dist::Zilla::Plugin::MetaYAML to generate META.yml at build (needed for older CPAN clients)
- Add Dist::Zilla::Plugin::ReadmeAnyFromPod to generate a README file in the dist (the README.pod was present in the root repo, but not in the resulting dist build)